### PR TITLE
fixed missing semicolon

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,7 @@ macro_rules! impl_fmt {
         }
     )*}
 }
-impl_fmt!(Show Octal Binary LowerHex UpperHex Pointer LowerExp UpperExp)
+impl_fmt!(Show Octal Binary LowerHex UpperHex Pointer LowerExp UpperExp);
 
 #[unstable = "trait is not stable"]
 impl<S: Encoder<E>, E, T: Encodable<S, E>> Encodable<S, E> for MuCell<T> {


### PR DESCRIPTION
Added a semicolon to fix the following compilation error:

```
➜  mucell git:(master) cargo build
   Compiling mucell v0.1.3 (file:///Users/awri10/src/rust/mucell)
/Users/awri10/src/rust/mucell/src/lib.rs:235:72: 235:73 error: macros that expand to items must either be surrounded with braces or followed by a semicolon
/mucell/src/lib.rs:235 impl_fmt!(Show Octal Binary LowerHex UpperHex Pointer LowerExp UpperExp)
```
