### PR TITLE
Use rustc-serialize instead of serialize crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ repository = "https://github.com/chris-morgan/mucell"
 readme = "README.md"
 keywords = ["cell", "container", "data-structure"]
 license = "MIT/Apache-2.0"
+
+[dependencies]
+rustc-serialize = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 #![warn(bad_style, unused, missing_docs)]
 
 #[phase(plugin, link)] extern crate core;
-extern crate serialize;
+extern crate "rustc-serialize" as serialize;
 extern crate rand;
 extern crate collections;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,7 @@ impl<T: Hash<S>, S = sip::SipState> Hash<S> for MuCell<T> {
 /// }
 ///
 /// fn main() {
-///     demo(&MuCell::new(Foo { bar: "panic".into_string() }));
+///     demo(&MuCell::new(Foo { bar: "panic".to_string() }));
 /// }
 /// ```
 ///


### PR DESCRIPTION
The serialize crate is being deprecated in favour of the one from
crates.io. PR: https://github.com/rust-lang/rust/pull/19820.

Also, I changed the deprecated into_string() call to to_string(), although maybe I should be using to_owned() from std::borrow::ToOwned?