### PR TITLE
Fix build error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@
 #![no_std]
 #![feature(no_std, unsafe_destructor, optin_builtin_traits)]
 #![feature(core, collections)]
+#![feature(negate_unsigned)]
 #![warn(bad_style, unused, missing_docs)]
 
 #[macro_use] extern crate core;


### PR DESCRIPTION
Fix build error like bellow

```
  Compiling mucell v0.1.17 (file:///home/hrysd/src/github.com/chris-morgan/mucell)

src/lib.rs:88:25: 88:27 error: unary negation of unsigned integers may be removed in the future
src/lib.rs:88 const MUTATING: usize = -1;
                                      ^~
src/lib.rs:88:27: 88:27 help: add #![feature(negate_unsigned)] to the crate attributes to enable
error: aborting due to previous error
Could not compile `mucell`.
```
